### PR TITLE
Install Bug - squishbox-install.bash -> $AUDIOCARDS not behaving as intended

### DIFF
--- a/squishbox-install.bash
+++ b/squishbox-install.bash
@@ -128,7 +128,7 @@ echo "What are you setting up?"
 echo "  1. SquishBox"
 echo "  2. Naked Raspberry Pi Synth"
 query "Choose" "1"; installtype=$response
-AUDIOCARDS=$(cat /proc/asound/cards | sed -n 's/.*\[//;s/ *\].*//p')
+readarray -t AUDIOCARDS <<< $(cat /proc/asound/cards | sed -n 's/.*\[//;s/ *\].*//p')
 if [[ $installtype == 1 ]]; then
     if [[ ! " ${AUDIOCARDS[*]} " =~ " sndrpihifiberry " ]]; then
         inform "This script must reboot your computer to activate your sound card."


### PR DESCRIPTION
fixes bug in squishbox-install.bash where $AUDIOCARDS was receiving all audiocard name strings in index 0 instead of having them populate successive indexes. This resulted in misconfigured setup files