### PR TITLE
Incorrect file paths in installer script

### DIFF
--- a/debian/squishbox-system@.service
+++ b/debian/squishbox-system@.service
@@ -7,7 +7,7 @@ Type=simple
 User=%i
 WorkingDirectory=/home/%i
 Environment=FLUIDPATCHER_CONFIG=/home/%i/SquishBox/fpatcherboxconf.yaml
-ExecStart=/usr/bin/python3 -m squishbox.scripts.launcher
+ExecStart=/usr/bin/python3 -m squishbox.apps.launcher
 Restart=on-failure
 LimitMEMLOCK=infinity
 LimitRTPRIO=90

--- a/squishbox-install.sh
+++ b/squishbox-install.sh
@@ -135,7 +135,7 @@ install_web_manager() {
         -e "s/__USERNAME__/$ESCAPED_USER/" \
         -e "s#__PASSWORD_HASH__#$ESCAPED_HASH#" \
         -e "s#__ROOT_PATH__#$ESCAPED_ROOT#" \
-        /usr/share/squishbox-web/index.php \
+        /usr/share/squishbox-web/index.php/index.php.template \
         > /tmp/squishbox-index.php
     sudo install -D -m 0644 /tmp/squishbox-index.php /var/www/html/index.php
 
@@ -157,7 +157,7 @@ detect_gpio_chip() {
     if [[ -e /dev/gpiochip4 ]]; then
         log "GPIO detected, updating config..."
         sudo sed -i 's|^gpio_chip:.*|gpio_chip: /dev/gpiochip4|' \
-            "$SB_DIR/squishboxconf.yaml" || true
+            "$SB_DIR/config/squishboxconf.yaml" || true
     fi
 }
 


### PR DESCRIPTION
I decided to try again with my v6 build today and ran into some issues with the latest installer. I also needed to `sudo apt install acl` due to 

    sudo: setfacl: command not found

But I didn't address that issue here. I still don't have a working unit, but at least the installer gets through clean after these changes.

<img width="2724" height="2737" alt="IMG_1517" src="https://github.com/user-attachments/assets/0d9d0765-90c2-41f7-abb0-6c00de2424d5" />

Service failed to start `journalctl -u squishbox-system@unrared.service `

    May 03 21:12:56 squidbox systemd[1]: Started squishbox-system@unrared.service - SquishBox (unrared).
    May 03 21:12:57 squidbox python3[599]: /usr/bin/python3: Error while finding module specification for 'squishbox.scripts.launcher' (ModuleNotFoundError: No module named 'squish>
    May 03 21:12:57 squidbox systemd[1]: squishbox-system@unrared.service: Main process exited, code=exited, status=1/FAILURE
    May 03 21:12:57 squidbox systemd[1]: squishbox-system@unrared.service: Failed with result 'exit-code'.

I modifed the command in the service to fix this ^ and was able to get to the UI.

<img width="4032" height="3024" alt="IMG_1518" src="https://github.com/user-attachments/assets/8979baa6-b663-4b44-bf4f-3b4b73b3314e" />

Then I ran into new issues.

`unrared@squidbox:~ $ /usr/bin/python3 -m squishbox.apps.launcher`

When trying to access **amsynthbox** using the rotary button:

```sh
Traceback (most recent call last):
  File "/home/unrared/.local/lib/python3.13/site-packages/squishbox/apps/launcher.py", line 21, in run_script
    spec.loader.exec_module(mod)
    ~~~~~~~~~~~~~~~~~~~~~~~^^^^^
  File "<frozen importlib._bootstrap_external>", line 1026, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/home/unrared/.local/lib/python3.13/site-packages/squishbox/apps/amsynthbox.py", line 309, in <module>
    if not CONFIG["banks_path"].exists():
           ~~~~~~^^^^^^^^^^^^^^
KeyError: 'banks_path'
```

When trying to access **fpatcherbox** using the rotary button:


```sh
Traceback (most recent call last):
  File "/home/unrared/.local/lib/python3.13/site-packages/squishbox/apps/launcher.py", line 23, in run_script
    mod.main()
    ~~~~~~~~^^
  File "/home/unrared/.local/lib/python3.13/site-packages/squishbox/apps/fpatcherbox.py", line 485, in main
    FPBox().run()
    ~~~~~^^
  File "/home/unrared/.local/lib/python3.13/site-packages/squishbox/apps/fpatcherbox.py", line 52, in __init__
    self.load_bank(CONFIG["fpatcherbox_path"])
                   ~~~~~~^^^^^^^^^^^^^^^^^^^^
KeyError: 'fpatcherbox_path'
```

----

I have a hunch we might have confusion with environment variables. Given the key error on `CONFIG["banks_path"]` seemed to trace back to the yaml config, that var is `FLUIDPATCHER_CONFIG`, so was it renamed to `SQUISHBOX_CONFIG` at some point? I tried subbing it in place to the python script but ran into new pain:

```sh
Traceback (most recent call last):
  File "<frozen runpy>", line 189, in _run_module_as_main
  File "<frozen runpy>", line 112, in _get_module_details
  File "/home/unrared/.local/lib/python3.13/site-packages/squishbox/__init__.py", line 15, in <module>
    from .config import CONFIG
  File "/home/unrared/.local/lib/python3.13/site-packages/squishbox/config.py", line 79, in <module>
    CONFIG = load_config(CONFIG_PATH.name)
  File "/home/unrared/.local/lib/python3.13/site-packages/squishbox/config.py", line 35, in load_config
    cfg = yaml.safe_load(pkg_default.read_text())
  File "/usr/lib/python3/dist-packages/yaml/__init__.py", line 125, in safe_load
    return load(stream, SafeLoader)
  File "/usr/lib/python3/dist-packages/yaml/__init__.py", line 81, in load
    return loader.get_single_data()
           ~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/lib/python3/dist-packages/yaml/constructor.py", line 49, in get_single_data
    node = self.get_single_node()
  File "/usr/lib/python3/dist-packages/yaml/composer.py", line 36, in get_single_node
    document = self.compose_document()
  File "/usr/lib/python3/dist-packages/yaml/composer.py", line 55, in compose_document
    node = self.compose_node(None, None)
  File "/usr/lib/python3/dist-packages/yaml/composer.py", line 84, in compose_node
    node = self.compose_mapping_node(anchor)
  File "/usr/lib/python3/dist-packages/yaml/composer.py", line 127, in compose_mapping_node
    while not self.check_event(MappingEndEvent):
              ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/yaml/parser.py", line 98, in check_event
    self.current_event = self.state()
                         ~~~~~~~~~~^^
  File "/usr/lib/python3/dist-packages/yaml/parser.py", line 438, in parse_block_mapping_key
    raise ParserError("while parsing a block mapping", self.marks[-1],
            "expected <block end>, but found %r" % token.id, token.start_mark)
yaml.parser.ParserError: while parsing a block mapping
  in "<unicode string>", line 1, column 1:
    fluidsettings:
    ^
expected <block end>, but found '<scalar>'
  in "<unicode string>", line 15, column 29:
    banks_path: {cfg_dir.parent}/banks
                                ^
```

----

I found the amsynth config file from `~/SquishBox/config/amsynthbox.yaml` but it only contained `{}` which doesn't even seem valid for a yaml file. Step by step I started adding properties to it until it contained this:

```yaml
banks_path: /usr/share/amsynth/banks/
currentbank_path: /usr/share/amsynth/banks/amsynth_factory.bank
midi_channel: 1
```

At this point, I was able to get to the patch selection UI (i.e. Darren 1, patch 1/26), but trying to load a bank resulted in:

```sh
Traceback (most recent call last):
  File "/home/unrared/.local/lib/python3.13/site-packages/squishbox/apps/launcher.py", line 21, in run_script
    spec.loader.exec_module(mod)
    ~~~~~~~~~~~~~~~~~~~~~~~^^^^^
  File "<frozen importlib._bootstrap_external>", line 1026, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/home/unrared/.local/lib/python3.13/site-packages/squishbox/apps/amsynthbox.py", line 458, in <module>
    save_state(CONFIG_PATH, CONFIG)
               ^^^^^^^^^^^
NameError: name 'CONFIG_PATH' is not defined
```